### PR TITLE
YALB-1451: Bug: npm run lint will not run

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "husky": "^7.0.4",
         "lint-staged": "^12.1.6",
+        "prettier": "<3.0.0",
         "semantic-release": "^18.0.1",
         "stylelint": "^14.2.0",
         "stylelint-config-prettier": "^9.0.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.25.4",
-    "eslint-plugin-prettier": "^4.0.0",
+    "eslint-plugin-prettier": "^5.0.0-alpha.1",
     "husky": "^7.0.4",
     "lint-staged": "^12.1.6",
     "semantic-release": "^18.0.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.25.4",
-    "eslint-plugin-prettier": "^5.0.0-alpha.1",
+    "eslint-plugin-prettier": "^4.0.0",
     "husky": "^7.0.4",
     "lint-staged": "^12.1.6",
     "semantic-release": "^18.0.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "husky": "^7.0.4",
     "lint-staged": "^12.1.6",
+    "prettier": "<3.0.0",
     "semantic-release": "^18.0.1",
     "stylelint": "^14.2.0",
     "stylelint-config-prettier": "^9.0.3",


### PR DESCRIPTION
## [YALB-1451: Bug: npm run lint will not run](https://yaleits.atlassian.net/browse/YALB-1451)

With the release of prettier 3.0, it no longer has a resolveConfig function, resulting in an error when using this repo in other projects. This is affecting both `eslint` and `stylelint` prettier plugins.

### Description of work
- Specifically targets `prettier` to be under `3.0.0`

### Functional testing steps:

#### For this repo
- [ ] Bring down this repo branch locally and cd into it
- [ ] `npm i -D`
- [ ] `npm pack`
- [ ] Verify it created a tgz file named `yalesites-org-eslint-config-and-other-formatting-0.0.0-development.tgz` (Make note of this path)

#### For yalesites-project
- [ ] Edit package.json, replacing the reference to yalesites-org/eslint-config-and-other-formatting on line 30 with:
`"@yalesites-org/eslint-config-and-other-formatting": "file:PATH_TO_yalesites-org-eslint-config-and-other-formatting-0.0.0-development.tgz",`
- [ ] `npm install --include=dev`
- [ ] `npm run lint`
- [ ] Verify that it ran successfully and did not error out
- [ ] Revert your package.json so you can still use your yalesites-project
